### PR TITLE
Fix loading module fab

### DIFF
--- a/plugin/MCPUnreal.uplugin
+++ b/plugin/MCPUnreal.uplugin
@@ -16,7 +16,8 @@
 		{ "Name": "ProceduralMeshComponent", "Enabled": true },
 		{ "Name": "PCG", "Enabled": true },
 		{ "Name": "GameplayAbilities", "Enabled": true },
-		{ "Name": "Niagara", "Enabled": true }
+		{ "Name": "Niagara", "Enabled": true },
+		{ "Name": "Fab", "Enabled": true }
 	],
 	"Modules": [
 		{

--- a/plugin/MCPUnreal.uplugin
+++ b/plugin/MCPUnreal.uplugin
@@ -17,6 +17,7 @@
 		{ "Name": "PCG", "Enabled": true },
 		{ "Name": "GameplayAbilities", "Enabled": true },
 		{ "Name": "Niagara", "Enabled": true },
+		{ "Name": "RemoteControl", "Enabled": true },
 		{ "Name": "Fab", "Enabled": true }
 	],
 	"Modules": [


### PR DESCRIPTION
In plugin using fab module, but didn't add dependence on fab plugin. And on loading project with this plugin have error with loading module.

## Summary

Brief description of the changes.

## Related Issues

Closes #

## Changes

-

## Test Plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run` passes
- [x] `make cpp-fmt-check` passes (if C++ files changed)
- [x] New tests added for new functionality
- [x] Tested with Claude Code (if tool changes)

## Checklist

- [ ] Code follows project conventions (see CLAUDE.md)
- [ ] Tool descriptions are specific and actionable
- [ ] No output on stdout (logging goes to stderr)
- [ ] Input validation on all tool parameters
- [ ] Errors are wrapped with context (`fmt.Errorf`)
- [ ] IMPLEMENTATION.md updated (if adding/changing tools)
